### PR TITLE
(docs) added npm scripts, re-linted familiarities

### DIFF
--- a/databases/mongo/models/familiarities.js
+++ b/databases/mongo/models/familiarities.js
@@ -88,9 +88,9 @@ module.exports = {
 };
 
 
-// let cb = ((result) => result)
-// let newCards = [{StudentID:'Jeff'}, {StudentID:'David'}, {StudentID:'JG'}, {StudentID:'Kay'}];
+// let cb = ((result) => result);
+// let newCards = [{StudentID: 'Jeff'}, {StudentID: 'David'}, {StudentID: 'JG'}, {StudentID: 'Kay'}];
 // module.exports.dropDB(cb);
 // module.exports.populateDB(newCards, cb);
-// module.exports.findOne({StudentID:'Jeff'}, cb);
-// module.exports.findAll(cb)
+// module.exports.findAll(cb);
+// module.exports.findCard({StudentID: 'Jeff'}, cb);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "engines": {
     "node": ">=6.4.0"
   },
-  "scripts": {},
+  "scripts": {
+    "start": "nodemon server/index.js",
+    "db": "mongod",
+    "bkgrnd-db": "sudo mongod --fork --logpath /var/log/mongodb.log"
+  },
   "dependencies": {
     "body-parser": "^1.17.1",
     "chai": "^3.5.0",


### PR DESCRIPTION
bkgrnd-db runs the mongod process in the background and logs the same information you'd see in the console to the filepath written at the end

Not sure about Kay's file structure or tooling currently, but here's what I came up with for an npm script for react compiling: 
"react-dev": "babel . --out-dir client_react/compiled --presets=es2015,react --ignore=databases,node_modules,client_react/compiled,server,test --source-maps inline --watch" 
(the recastly sprint has an explanation of this script)
Or, if you're using webpack,
"react-dev": "webpack -d --watch"

Kay, add the script you'd use